### PR TITLE
[WIP] Fix CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]  # windows-2019, macOS-10.15
+        os: [ubuntu-20.04, windows-2019, macOS-10.15]
 
     env:
       CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable -y"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04]  # windows-2019, macOS-10.15
 
     env:
       CIBW_SKIP: "?p27-* ?p35-*"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,6 @@
 name: Build
 
-on:
-  push:
-    tags:
-    - 'v*'
+on: push
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
           python -m pip install -r requirements.txt
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.10.0
+        run: python -m pip install cibuildwheel==2.1.1
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir "${{ env.BUILD_OUTPUT_PATH }}"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,8 +33,8 @@ jobs:
         run: python -m pip install cibuildwheel==1.10.0
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir "$BUILD_OUTPUT_PATH"
+        run: python -m cibuildwheel --output-dir "${{ env.BUILD_OUTPUT_PATH }}"
 
       - uses: actions/upload-artifact@v2
         with:
-          path: "./$BUILD_OUTPUT_PATH/*.whl"
+          path: "./${{ env.BUILD_OUTPUT_PATH }}/*.whl"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,8 +14,10 @@ jobs:
         os: [ubuntu-20.04, windows-2019, macOS-10.15]
 
     env:
-      CIBW_SKIP: ?p27-*
+      CIBW_SKIP: "?p27-* ?p35-*"
       CIBW_BUILD_VERBOSITY: 3
+      CIBW_BEFORE_BUILD: "python -m pip install --upgrade pip && python -m pip install --upgrade wheel setuptools setuptools-rust"
+      CIBW_BEFORE_BUILD_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable"
       BUILD_OUTPUT_PATH: wheelhouse
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       CIBW_SKIP: "?p27-* ?p35-*"
       CIBW_BUILD_VERBOSITY: 3
-      CIBW_BEFORE_BUILD: "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable && python -m pip install --upgrade pip && python -m pip install --upgrade wheel setuptools setuptools-rust"
+      CIBW_BEFORE_BUILD: "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable && source $HOME/.cargo/env && python -m pip install --upgrade pip && python -m pip install --upgrade wheel setuptools setuptools-rust"
       BUILD_OUTPUT_PATH: wheelhouse
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,9 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
       - name: Install requirements
         run: |
-          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: "1"
           CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y && yum install -y openssl-devel"
           CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
-          CIBW_SKIP: "pp* *-win32 cp37* cp38* cp39* cp10*"
+          CIBW_SKIP: "*-win32"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,8 +16,7 @@ jobs:
     env:
       CIBW_SKIP: "?p27-* ?p35-*"
       CIBW_BUILD_VERBOSITY: 3
-      CIBW_BEFORE_BUILD: "python -m pip install --upgrade pip && python -m pip install --upgrade wheel setuptools setuptools-rust"
-      CIBW_BEFORE_BUILD_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable"
+      CIBW_BEFORE_BUILD: "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable && python -m pip install --upgrade pip && python -m pip install --upgrade wheel setuptools setuptools-rust"
       BUILD_OUTPUT_PATH: wheelhouse
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,9 +11,10 @@ jobs:
         os: [ubuntu-20.04]  # windows-2019, macOS-10.15
 
     env:
-      CIBW_SKIP: "?p27-* ?p35-*"
-      CIBW_BUILD_VERBOSITY: 3
-      CIBW_BEFORE_BUILD: "curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=stable && source $HOME/.cargo/env && python -m pip install --upgrade pip && python -m pip install --upgrade wheel setuptools setuptools-rust"
+      CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable -y"
+      CIBW_BUILD_VERBOSITY: "3"
+      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+      CIBW_SKIP: "?p27-* ?p35-* pp* *-win32"
       BUILD_OUTPUT_PATH: wheelhouse
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: stable
+          override: true
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,9 @@
 name: Build
 
-on: push
+on:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build_wheels:
@@ -8,34 +11,44 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-10.15]
-
-    env:
-      CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=stable -y"
-      CIBW_BUILD_VERBOSITY: "3"
-      CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
-      CIBW_SKIP: "?p27-* ?p35-* pp* *-win32"
-      BUILD_OUTPUT_PATH: wheelhouse
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install requirements
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.1.1
-
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir "${{ env.BUILD_OUTPUT_PATH }}"
+      - uses: pypa/cibuildwheel@v2.1.2
+        env:
+          CIBW_BUILD_VERBOSITY: "1"
+          CIBW_BEFORE_ALL_LINUX: "curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y && yum install -y openssl-devel"
+          CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin"'
+          CIBW_SKIP: "pp* *-win32 cp37* cp38* cp39* cp10*"
 
       - uses: actions/upload-artifact@v2
         with:
-          path: "./${{ env.BUILD_OUTPUT_PATH }}/*.whl"
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Build sdist
+        run: python -m pip install -r requirements.txt && python setup.py sdist
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+      needs: [build_wheels, build_sdist]
+      runs-on: ubuntu-20.04
+      steps:
+        - uses: actions/download-artifact@v2
+          with:
+            name: artifact
+            path: dist
+
+        - uses: pypa/gh-action-pypi-publish@v1.4.2
+          with:
+            user: __token__
+            password: ${{ secrets.pypi_token }}
+            repository_url: https://test.pypi.org/legacy/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Lonami Exo <totufals@hotmail.com>"]
 edition = "2018"
 
 [dependencies]
-grammers-crypto = "0.2.0"
-pyo3 = { version = "0.13.2", features = ["extension-module"] }
+grammers-crypto = "0.3.0"
+pyo3 = { version = "0.14.4", features = ["extension-module"] }
 
 [lib]
 name = "cryptg"

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@ cryptg
 This is a small native extension for Python 3 to help libraries that want to
 work with the Telegram API, which uses the uncommon AES-IGE mode for it.
 
+Note that while this wrapper library is licensed under CC0, the Rust dependencies
+have their own license.
+
 .. |logo| image:: https://raw.githubusercontent.com/cher-nov/cryptg/master/logo.png
     :target: https://github.com/cher-nov/cryptg
     :alt: cryptg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools-rust"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+requires = [
+    "setuptools-rust>=0.12.1",
+    "setuptools>=58.1.0",
+    "wheel>=0.37.0",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-setuptools-rust
-setuptools
-wheel
+setuptools-rust>=0.12.1
+setuptools>=58.1.0
+wheel>=0.37.0

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,11 @@ def main(args):
             "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
 
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.3",
-            "Programming Language :: Python :: 3.4",
-            "Programming Language :: Python :: 3.5",
-            "Programming Language :: Python :: 3.6"
+            "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
         ],
         keywords="telegram crypto cryptography mtproto aes",
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use pyo3::{prelude::*, types::PyBytes, wrap_pyfunction};
 
 /// Encrypts the input plain text with the 32 bytes key and IV.
 #[pyfunction]
-#[text_signature = "(plain, key, iv)"]
+#[pyo3(text_signature = "(plain, key, iv)")]
 fn encrypt_ige(plain: &[u8], key: &[u8], iv: &[u8]) -> PyResult<Py<PyBytes>> {
     let mut key_array = [0; 32];
     if key.len() != key_array.len() {
@@ -22,7 +22,7 @@ fn encrypt_ige(plain: &[u8], key: &[u8], iv: &[u8]) -> PyResult<Py<PyBytes>> {
 
 /// Decrypts the input cipher text with the 32 bytes key and IV.
 #[pyfunction]
-#[text_signature = "(cipher, key, iv)"]
+#[pyo3(text_signature = "(cipher, key, iv)")]
 fn decrypt_ige(cipher: &[u8], key: &[u8], iv: &[u8]) -> PyResult<Py<PyBytes>> {
     let mut key_array = [0; 32];
     if key.len() != key_array.len() {


### PR DESCRIPTION
(Please squash this into a single commit - a lot were made for testing).

Now I'm stuck here and I can't seem to figure this one out:

<details><summary>Error log "Missing 'Version:' header and/or PKG-INFO file"</summary>

```
Building cp36-macosx_x86_64 wheel
CPython 3.6 macOS x86_64

Installing Python cp36...
  
  + Download https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg to /tmp/Python.pkg
  + sudo installer -pkg /tmp/Python.pkg -target /
  installer: Package name is Python
  installer: Upgrading at base path /
  installer: The upgrade was successful.
  + sudo /Library/Frameworks/Python.framework/Versions/3.6/bin/python3 /Users/runner/hostedtoolcache/Python/3.9.6/x64/lib/python3.9/site-packages/cibuildwheel/resources/install_certifi.py
  The directory '/Users/runner/Library/Caches/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  The directory '/Users/runner/Library/Caches/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  Collecting certifi
    Downloading https://files.pythonhosted.org/packages/05/1b/0a0dece0e8aa492a6ec9e4ad2fe366b511558cdc73fd3abc82ba7348e875/certifi-2021.5.30-py2.py3-none-any.whl (145kB)
  /Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_internal/req/req_install.py:339: UserWarning: Unbuilt egg for Unknown [unknown version] (/Users/runner/work/cryptg/cryptg)
    self.satisfied_by = pkg_resources.get_distribution(str(no_marker))
  Exception:
  Traceback (most recent call last):
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2570, in version
      return self._version
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2677, in __getattr__
      raise AttributeError(attr)
  AttributeError: _version
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_internal/cli/base_command.py", line 143, in main
      status = self.run(options, args)
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_internal/commands/install.py", line 349, in run
      self._warn_about_conflicts(to_install)
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_internal/commands/install.py", line 475, in _warn_about_conflicts
      package_set, _dep_info = check_install_conflicts(to_install)
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_internal/operations/check.py", line 98, in check_install_conflicts
      package_set = create_package_set_from_installed()
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_internal/operations/check.py", line 41, in create_package_set_from_installed
      package_set[name] = PackageDetails(dist.version, dist.requires())
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2575, in version
      raise ValueError(tmpl % self.PKG_INFO, self)
  ValueError: ("Missing 'Version:' header and/or PKG-INFO file", Unknown [unknown version] (/Users/runner/work/cryptg/cryptg))
  You are using pip version 18.1, however version 21.2.4 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.
   -- pip install --upgrade certifi
  Traceback (most recent call last):
    File "/Users/runner/hostedtoolcache/Python/3.9.6/x64/lib/python3.9/site-packages/cibuildwheel/resources/install_certifi.py", line 55, in <module>
      main()
    File "/Users/runner/hostedtoolcache/Python/3.9.6/x64/lib/python3.9/site-packages/cibuildwheel/resources/install_certifi.py", line 32, in main
      [sys.executable, "-E", "-s", "-m", "pip", "install", "--upgrade", "certifi"]
    File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 311, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['/Library/Frameworks/Python.framework/Versions/3.6/bin/python3', '-E', '-s', '-m', 'pip', 'install', '--upgrade', 'certifi']' returned non-zero exit status 2.
Error: Command ['sudo', '/Library/Frameworks/Python.framework/Versions/3.6/bin/python3', '/Users/runner/hostedtoolcache/Python/3.9.6/x64/lib/python3.9/site-packages/cibuildwheel/resources/install_certifi.py'] failed with code 1. None
```

</details>

* The removal of tiny-AES is due to warnings.
* The introduction of `pyproject.toml` seems to make `cibuildwheel` Just Work™ (or at least, get closer).
* 0.2 of grammers-crypto was failing so I bumped that up, and PyO3 while I was at it.
* I'll revert the `on: push` once this is working.
* The env.CIBW changes are ~~stolen~~ inspired from the Rust projects at https://cibuildwheel.readthedocs.io/en/stable/working-examples/.
* I bumped cibuildwheel just in case.