### PR TITLE
Also include Cargo.lock in packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include Cargo.toml
+include Cargo.toml Cargo.lock
 recursive-include src *
 graft LICENSES
 global-exclude .git*


### PR DESCRIPTION
Follow-up b5096aa58e2d9a0b345945abf23c103308d7df53 with actually including Cargo.lock in the sdist, so you can build PyPI artifacts reproducibly.