### PR TITLE
Fix ZRAM kmod version mismatch in CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-20.04' && matrix.arch == 'aarch64' }}
         run: |
           sudo apt-get update -yq
-          sudo apt-get install -yq linux-modules-extra-azure zram-tools
+          sudo apt-get install -yq "linux-modules-extra-$(uname -r)" zram-tools
           echo -e 'CORES=1\nPERCENTAGE=100' | sudo tee -a /etc/default/zramswap
           sudo systemctl restart zramswap
           swapon


### PR DESCRIPTION
When Ubuntu has uploaded a new kernel version to their APT repo, the GHA runner image may still be outdated. In such a case, installing unversioned linux-modules-extra-* leads to kmod version mismatch.

This may help prevent CI from getting stuck: 
https://github.com/cher-nov/cryptg/issues/29#issuecomment-1751995882